### PR TITLE
set Environment.app in .init_app

### DIFF
--- a/src/flaskext/assets.py
+++ b/src/flaskext/assets.py
@@ -95,7 +95,7 @@ class Environment(BaseEnvironment):
     config_storage_class = FlaskConfigStorage
 
     def __init__(self, app=None):
-        self.app = app
+        self.app = None
         super(Environment, self).__init__()
         if app:
             self.init_app(app)
@@ -159,6 +159,7 @@ class Environment(BaseEnvironment):
         return path.abspath(path.join(directory, filename))
 
     def init_app(self, app):
+        self.app = app
         app.jinja_env.add_extension('webassets.ext.jinja2.AssetsExtension')
         app.jinja_env.assets_environment = self
 


### PR DESCRIPTION
The example from http://elsdoerfer.name/docs/flask-assets/ does not work, because .app is None.

``` python
app = Flask(__name__)
assets = flaskext.assets.Environment()
assets.init_app(app)
```
