### PR TITLE
Import from 'flaskext' was changed to 'flask.ext'.

### DIFF
--- a/src/flask_assets.py
+++ b/src/flask_assets.py
@@ -255,7 +255,7 @@ class Environment(BaseEnvironment):
         [self.register(name, bundle) for name, bundle in bundles.iteritems()]
 
 try:
-    from flaskext import script
+    from flask.ext import script
 except ImportError:
     pass
 else:


### PR DESCRIPTION
Before version 0.8, flask used `flaskext` namespace:
http://flask.pocoo.org/docs/extensions/#flask-before-0-8
But with 0.8 this behaviour was changed.

Probably, major version's increment needed. Otherwise,
backward compatibility could be added, using:

```
import flaskext_compat
flaskext_compat.activate()
from flask.ext import script
```
