### PR TITLE
documentation regarding babel configuration

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -144,6 +144,27 @@ configuration. The following two statements are equivalent:
 For a list of available settings, see the full
 :ref:`webassets documentation <webassets:environment-configuration>`.
 
+Babel Configuration
+~~~~~~~~~~~~~~~~~~~
+
+If you use `Babel`_ for internationalization, then you will need to
+add the extension to your babel configuration file
+as ``webassets.ext.jinja2.AssetsExtension``
+
+Otherwise, babel will not extract strings from any templates that
+include an ``assets`` tag.
+
+Here is an example ``babel.cfg``:
+
+.. code-block:: python
+
+    [python: **.py]
+    [jinja2: **.html]
+    extensions=jinja2.ext.autoescape,jinja2.ext.with_,webassets.ext.jinja2.AssetsExtension
+
+
+.. _Babel: http://babel.edgewall.org/
+
 
 Management Command
 ------------------


### PR DESCRIPTION
Added a small section to the configuration documentation regarding babel configuration in case any other flask-assets users also use babel for internationalization. 

Babel will fail to extract any strings from templates that contain an `assets` tag unless `webassets.ext.jinja2.AssetsExtension` is listed as an extension in your babel configuration file.

This took me quite a while to track down, so I hope this will save time for someone else!
