### PR TITLE
Support factory pattern for creating apps

### DIFF
--- a/src/flask_assets.py
+++ b/src/flask_assets.py
@@ -262,6 +262,8 @@ class Environment(BaseEnvironment):
         """
         if self.app is not None:
             return self.app
+        elif hasattr(self, '_app_from_init_app'):
+            return self._app_from_init_app
         else:
             ctx = _request_ctx_stack.top
             if ctx is not None:
@@ -287,6 +289,8 @@ class Environment(BaseEnvironment):
     """)
 
     def init_app(self, app):
+        if not self.app:
+            self._app_from_init_app = app
         app.jinja_env.add_extension('webassets.ext.jinja2.AssetsExtension')
         app.jinja_env.assets_environment = self
 


### PR DESCRIPTION
When doing

```
assets_env = Environment()
assets_env.init_app(app)
```

I get `RuntimeError: assets instance not bound to an application, and no application in current context`.
