### PR TITLE
A small update to docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -120,7 +120,7 @@ simply define everything inside your template:
 
 .. code-block:: jinja
 
-    {% assets filter="jsmin", output="gen/packed.js",
+    {% assets filters="jsmin", output="gen/packed.js",
               "common/jquery.js", "site/base.js", "site/widgets.js" %}
         <script type="text/javascript" src="{{ ASSET_URL }}"></script>
     {% endassets %}


### PR DESCRIPTION
Template option "filter" was renamed to "filters" in webassets.

The example in docs used the old name and thus produced an ImminentDeprecationWarning: The "filter" option of the {% assets %} template tag has been renamed to "filters" for consistency reasons
