### PR TITLE
Application context

### DIFF
--- a/src/flask_assets.py
+++ b/src/flask_assets.py
@@ -275,10 +275,19 @@ class Environment(BaseEnvironment):
         """
         if self.app is not None:
             return self.app
-        else:
-            ctx = _request_ctx_stack.top
-            if ctx is not None:
-                return ctx.app
+
+        ctx = _request_ctx_stack.top
+        if ctx is not None:
+            return ctx.app
+
+        try:
+            from flask import _app_ctx_stack
+            app_ctx = _app_ctx_stack.top
+            if app_ctx is not None:
+                return app_ctx.app
+        except ImportError:
+            pass
+
         raise RuntimeError('assets instance not bound to an application, '+
                             'and no application in current context')
 


### PR DESCRIPTION
Hi,

One of the error messages regarding application context is a bit confusing (here: https://github.com/miracle2k/flask-assets/blob/master/src/flask_assets.py#L282), you're asking for an "application context" whereas what you want is a "request context" (at the time you wrote this I guess application context didn't exist).

I wrote a small PR to also check for an app context.

Basically we are now able to do:

```
with app.app_context():
    cmdenv = CommandLineEnvironment(environment, log)
    cmdenv.build()
```

(It's my first PR to an open source project btw :))
