### PR TITLE
Fix setup.py so it references webassets==dev, instead of webassets==0.9....

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def parse_version(asignee):
     import os, re
     here = os.path.dirname(os.path.abspath(__file__))
     version_re = re.compile(
-        r'__version__ = (\(.*?\))')
+        r'%s = (\(.*?\))' % asignee)
     with open(os.path.join(here, 'src', 'flask_assets.py')) as fp:
         for line in fp:
             match = version_re.search(line)


### PR DESCRIPTION
...dev which doesnt exist

This allows the development version to install properly with pip
