### PR TITLE
Add support for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - 2.6
 install: pip install tox
 # List envs explicitly to skip PyPy
-script: tox -e py26_flask08,py27_flask08
+script: tox -e py26_flask08,py27_flask08,py33_flask010
 notifications:
   email:
     - michael@elsdoerfer.com

--- a/requirements-dev.pip
+++ b/requirements-dev.pip
@@ -3,4 +3,4 @@ Flask>=0.8
 Flask-Script>=0.3.3
 webassets>=0.8
 PyYAML
-pyScss==1.1.5
+pyScss>=1.1.5

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,8 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],

--- a/src/flask_assets.py
+++ b/src/flask_assets.py
@@ -1,4 +1,4 @@
-from __future__ import with_statement
+from __future__ import print_function
 from os import path
 from flask import _request_ctx_stack
 from flask.templating import render_template_string
@@ -234,7 +234,7 @@ class FlaskResolver(Resolver):
             try:
                 from flask.ext.s3 import url_for
             except ImportError as e:
-                print "You must have Flask S3 to use FLASK_ASSETS_USE_S3 option"
+                print("You must have Flask S3 to use FLASK_ASSETS_USE_S3 option")
                 raise e
         else:
             from flask import url_for
@@ -315,12 +315,14 @@ class Environment(BaseEnvironment):
     def from_yaml(self, path):
         """Register bundles from a YAML configuration file"""
         bundles = YAMLLoader(path).load_bundles()
-        [self.register(name, bundle) for name, bundle in bundles.iteritems()]
+        for name in bundles:
+            self.register(name, bundles[name])
 
     def from_module(self, path):
         """Register bundles from a Python module"""
         bundles = PythonLoader(path).load_bundles()
-        [self.register(name, bundle) for name, bundle in bundles.iteritems()]
+        for name in bundles:
+            self.register(name, bundles[name])
 
 try:
     from flask.ext import script

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,8 @@
 """The Environment configuration is hooked up to the Flask config dict.
 """
 
-from __future__ import with_statement
-from helpers import check_warnings
+from __future__ import absolute_import
+from tests.helpers import check_warnings
 
 from nose.tools import assert_raises
 from flask import Flask

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 from nose.tools import assert_raises
 from nose import SkipTest
-from helpers import TempEnvironmentHelper
+from tests.helpers import TempEnvironmentHelper
 
 
 class TestFilters(TempEnvironmentHelper):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,10 +1,10 @@
-from __future__ import with_statement
+from __future__ import absolute_import
 from nose.tools import assert_raises
 
 from flask import Flask
 from flask.ext.assets import Environment, Bundle
 from webassets.bundle import get_all_bundle_files
-from helpers import TempEnvironmentHelper, Module, Blueprint
+from tests.helpers import TempEnvironmentHelper, Module, Blueprint
 
 
 def test_import():
@@ -29,7 +29,7 @@ class TestUrlAndDirectory(TempEnvironmentHelper):
         TempEnvironmentHelper.setup(self)
 
         self.app = Flask(__name__, static_path='/app_static')
-        import test_module
+        from tests import test_module
         if not Blueprint:
             self.module = Module(test_module.__name__, name='module',
                                  static_path='/mod_static')
@@ -197,7 +197,7 @@ class TestBlueprints(TempEnvironmentHelper):
 
     def make_blueprint(self, name='module', import_name=None, **kw):
         if not import_name:
-            import test_module
+            from tests import test_module
             import_name = test_module.__name__
 
         if not Blueprint:

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,11 +1,11 @@
-from __future__ import with_statement
+from __future__ import absolute_import
 
 import sys
 from nose import SkipTest
 from flask import Flask
 from flask.ext.assets import Environment, ManageAssets
 from webassets.script import GenericArgparseImplementation
-from helpers import TempEnvironmentHelper
+from tests.helpers import TempEnvironmentHelper
 
 try:
     from flaskext.script import Manager
@@ -80,4 +80,4 @@ class TestScript(TempEnvironmentHelper):
         mgmt.handle('test', 'assets', ['--parse-templates', 'build'])
 
         assert self.exists('output')
-        
+

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,19 @@ commands = nosetests tests
 
 # Addding/Removing venvs here must be reflected in .travis.yml!
 
+[testenv:py33_flask010]
+basepython = python3.3
+deps =
+    nose==1.0.0
+    flask>=0.10
+    flask-script>=0.6.0
+    webassets==dev
+    pyyaml==3.10
+    pyScss>=1.2.0
+
 [testenv:py27_flask08]
 basepython = python2.7
-deps = 
+deps =
     nose==1.0.0
     flask==0.8
     flask-script==0.3.1
@@ -16,7 +26,7 @@ deps =
 
 [testenv:py26_flask08]
 basepython = python2.6
-deps = 
+deps =
     nose==1.0.0
     flask==0.8
     flask-script==0.3.1
@@ -26,7 +36,7 @@ deps =
 
 [testenv:pypy_flask08]
 basepython = pypy
-deps = 
+deps =
     nose==1.0.0
     flask==0.8
     flask-script==0.3.1


### PR DESCRIPTION
**tl;dr** Support is being added for Python 3.3, dropped for Python 2.5.

In order to support Python 3, print needs to be used as a function,
imports need to be absolute, and the iter\* methods of dicts cannot be
used.

The first is handled with an import from `__future__`. The second is
handled with an import from `__future__` and changes to local imports in
the test suite.

The final change comes in the form of replacing two list comprehensions
with regular for loops that iterate over the dicts' keys rather than
using iteritems (or items in Python 3). The list comprehensions are
being removed because they are not used anywhere; there is no need to
allocate the memory for the lists. The iteration is changing because the
dicts are not being mutated inside the loops. Iterating over the keys
allows for simpler code that supports both Python 2 and Python 3.

tox and Travis CI tests are being updated to include Python 3.3. The
versions used to test it inside tox are consistent with Python 2.6 and
2.7 except for libraries that didn't add support for Python 3 until a
later version. The requirements change is also being reflected in the
development requirements. While PyScss 1.1.5 is being kept for Python
2.x, it is being changed to a minimum requirement as Python 3 support
wasn't added until 1.2.0. Changing this allows for future development
using Python 3.

Finally, these changes drop support for Python 2.5. Support for
print_function wasn't added to `__future__` until Python 2.6.
