### PR TITLE
Updated the Environment class to work correctly with Flask Application Factories

### DIFF
--- a/src/flask_assets.py
+++ b/src/flask_assets.py
@@ -263,7 +263,7 @@ class Environment(BaseEnvironment):
     resolver_class = FlaskResolver
 
     def __init__(self, app=None):
-        self.app = app
+        self.app = None
         super(Environment, self).__init__()
         if app:
             self.init_app(app)
@@ -309,6 +309,7 @@ class Environment(BaseEnvironment):
     """)
 
     def init_app(self, app):
+        self.app = app
         app.jinja_env.add_extension('webassets.ext.jinja2.AssetsExtension')
         app.jinja_env.assets_environment = self
 


### PR DESCRIPTION
Hey there,

Currently the **init_app** function isn't working correctly due to a minor bug that I've repaired in this commit.

Here's some sample code that demonstrates the problem:

``` python
#!/usr/bin/env python
from flask import Flask
from flask.ext.assets import Environment


def create_app():
    app = Flask(__name__)
    assets.init_app(app)
    print assets.auto_build
    return app

assets = Environment()
app = create_app()

if __name__ == "__main__":
    app.run()
```

The output is as follows:

``` bash
Traceback (most recent call last):
  File "./app.py", line 13, in <module>
    app = create_app()
  File "./app.py", line 9, in create_app
    print assets.auto_build
  File "/home/fots/.virtualenv/flask/local/lib/python2.7/site-packages/webassets/env.py", line 504, in _get_auto_build
    return self.config['auto_build']
  File "/home/fots/.virtualenv/flask/local/lib/python2.7/site-packages/flask_assets.py", line 85, in __getitem__
    if self.env._app:
  File "/home/fots/.virtualenv/flask/local/lib/python2.7/site-packages/flask_assets.py", line 260, in _app
    'and no application in current context')
RuntimeError: assets instance not bound to an application, and no application in current context
```

As a comparison, here's a version which doesn't use factories and works as expected:

``` python
#!/usr/bin/env python
from flask import Flask
from flask.ext.assets import Environment

app = Flask(__name__)
assets = Environment(app)
print assets.auto_build


if __name__ == "__main__":
    app.run()
```

And the output is:

``` bash
True
 * Running on http://127.0.0.1:5000/
```

This commit repairs application factories to work correctly again by ensuring that **self.app** is set when the **init_app** function is called.

Cheers
Fotis
