### PR TITLE
manually set install requires to 0.10.dev so that install works when web...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,30 +11,9 @@ merging, minifying and compiling CSS and Javascript files.
 from __future__ import with_statement
 from setuptools import setup
 
-# Figure out the version; this could be done by importing the
-# module, though that requires dependencies to be already installed,
-# which may not be the case when processing a pip requirements
-# file, for example.
-def parse_version(asignee):
-    import os, re
-    here = os.path.dirname(os.path.abspath(__file__))
-    version_re = re.compile(
-        r'%s = (\(.*?\))' % asignee)
-    with open(os.path.join(here, 'src', 'flask_assets.py')) as fp:
-        for line in fp:
-            match = version_re.search(line)
-            if match:
-                version = eval(match.group(1))
-                return ".".join(map(str, version))
-        else:
-            raise Exception("cannot find version")
-version = parse_version('__version__')
-webassets_version = parse_version('__webassets_version__')
-
-
 setup(
     name='Flask-Assets',
-    version=version,
+    version='0.10.dev',
     url='http://github.com/miracle2k/flask-assets',
     license='BSD',
     author='Michael Elsdoerfer',
@@ -48,7 +27,7 @@ setup(
     platforms='any',
     install_requires=[
         'Flask>=0.8',
-        'webassets==%s' % webassets_version,
+        'webassets>=0.10.dev'
     ],
     classifiers=[
         'Environment :: Web Environment',

--- a/src/flask_assets.py
+++ b/src/flask_assets.py
@@ -8,10 +8,6 @@ from webassets.filter import Filter, register_filter
 from webassets.loaders import PythonLoader, YAMLLoader
 
 
-__version__ = (0, 10, 'dev')
-__webassets_version__ = ('dev',)  # webassets core compatibility. used in setup.py
-
-
 __all__ = ('Environment', 'Bundle',)
 
 


### PR DESCRIPTION
...assets 0.10.dev is installed

Attempting to install Flask-Assets currently fails with 

```
Could not find a version that satisfies the requirement webassets==dev (from Flask-Assets==0.10.dev) (from versions: 0.4, 0.5, 0.6, 0.7.1, 0.7, 0.8, 0.9)
No distributions matching the version for webassets==dev (from Flask-Assets==0.10.dev)
```

You will still need to upload `webassets==0.10.dev` to PyPi or add to the Flask-Assets documentation that `webassets` should be install directly from GitHub.
