### PR TITLE
Two small changes

### DIFF
--- a/src/flask_assets.py
+++ b/src/flask_assets.py
@@ -411,6 +411,6 @@ else:
             prog = '%s %s' % (os.path.basename(sys.argv[0]), sys.argv[1])
 
             impl = self.implementation(self.env, prog=prog, log=self.log)
-            impl.main(args)
+            return impl.main(args)
 
     __all__ = __all__ + ('ManageAssets',)


### PR DESCRIPTION
Set `self.app` in `init_app` so that a simple example like this will work:

``` python
from flask import Flask
from flask.ext.assets import Environment
env = Environment()
app = Flask(__name__)
env.init_app(app)
env.debug = False
```

(Will throw `RuntimeError: assets instance not bound to an application, and no application in current context` without this).

Return value from webassets `main` so that deployment scripts can catch errors.
Example: https://github.com/paulegan/flask-assets-dist-example/blob/master/setup.py#L21
