### PR TITLE
webassets-version: use __webassets_version__ = (0, 10, 'dev')

### DIFF
--- a/src/flask_assets.py
+++ b/src/flask_assets.py
@@ -9,7 +9,7 @@ from webassets.loaders import PythonLoader, YAMLLoader
 
 
 __version__ = (0, 10, 'dev')
-__webassets_version__ = ('dev',)  # webassets core compatibility. used in setup.py
+__webassets_version__ = (0, 10, 'dev',)  # webassets core compatibility. used in setup.py
 
 
 __all__ = ('Environment', 'Bundle',)


### PR DESCRIPTION
In lieu of [#67](https://github.com/miracle2k/flask-assets/pull/67), can we at least update this so that `python setup.py install` will work when `webassets==0.10.dev` is already installed? Users need to be able to track specific versions.
