### PR TITLE
url-property: add url as a property that can be determined from the app context

### DIFF
--- a/src/flask_assets.py
+++ b/src/flask_assets.py
@@ -307,6 +307,14 @@ class Environment(BaseEnvironment):
     directory = property(get_directory, set_directory, doc=
     """The base directory to which all paths will be relative to.
     """)
+    def set_url(self, url):
+        self.config['url'] = url
+    def get_url(self):
+        if self.config.get('url') is not None:
+            return self.config['url']
+        return self._app.static_url_path
+    url = property(get_url, set_url, doc=
+    """The base url to which all static urls will be relative to.""")
 
     def init_app(self, app):
         app.jinja_env.add_extension('webassets.ext.jinja2.AssetsExtension')


### PR DESCRIPTION
This repeats the hack that's done fore `directory` to `url` so that filters that use `self.ctx.url` work, as it is in the [Compass filter](https://github.com/miracle2k/webassets/blob/master/src/webassets/filter/compass.py#L191).
