### PR TITLE
Fix flask-script assets build command

### DIFF
--- a/src/flask_assets.py
+++ b/src/flask_assets.py
@@ -149,7 +149,7 @@ class FlaskResolver(Resolver):
     def split_prefix(self, ctx, item):
         """See if ``item`` has blueprint prefix, return (directory, rel_path).
         """
-        app = ctx.environment._app
+        app = ctx._app
         try:
             if hasattr(app, 'blueprints'):
                 blueprint, name = item.split('/', 1)


### PR DESCRIPTION
Fixes the flask-assets ManageCommand for building. The Environment instance found is the environment itself, which does not have an attribute "environment". If I am simply using this wrong (i have tried letting it find my environment as well) please let me know