### PR TITLE
Update Flask extension imports for Flask 0.11

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,7 @@ registering your assets with it in the form of so called *bundles*.
 .. code-block:: python
 
     from flask import Flask
-    from flask.ext.assets import Environment, Bundle
+    from flask_assets import Environment, Bundle
 
     app = Flask(__name__)
     assets = Environment(app)
@@ -59,7 +59,7 @@ rather than passing a fixed application object:
 .. code-block:: python
 
     app = Flask(__name__)
-    assets = flask.ext.assets.Environment()
+    assets = flask_assets.Environment()
     assets.init_app(app)
 
 
@@ -206,7 +206,7 @@ as ``flaskext.assets.ManageAssets``:
 
 .. code-block:: python
 
-    from flask.ext.assets import ManageAssets
+    from flask_assets import ManageAssets
     manager = Manager(app)
     manager.add_command("assets", ManageAssets(assets_env))
 

--- a/example/app.py
+++ b/example/app.py
@@ -4,7 +4,7 @@ from os import path
 sys.path.insert(0, path.join(path.dirname(__file__), '../src'))
 
 from flask import Flask, render_template, url_for
-from flask.ext.assets import Environment, Bundle
+from flask_assets import Environment, Bundle
 
 app = Flask(__name__)
 

--- a/src/flask_assets.py
+++ b/src/flask_assets.py
@@ -227,7 +227,7 @@ class FlaskResolver(Resolver):
         glob instruction that was resolved to multiple files.
 
         If app.config("FLASK_ASSETS_USE_S3") exists and is True
-        then we import the url_for function from flask.ext.s3,
+        then we import the url_for function from flask_s3,
         otherwise we import url_for from flask directly.
 
         If app.config("FLASK_ASSETS_USE_CDN") exists and is True
@@ -235,13 +235,13 @@ class FlaskResolver(Resolver):
         """
         if ctx.environment._app.config.get("FLASK_ASSETS_USE_S3"):
             try:
-                from flask.ext.s3 import url_for
+                from flask_s3 import url_for
             except ImportError as e:
                 print("You must have Flask S3 to use FLASK_ASSETS_USE_S3 option")
                 raise e
         elif ctx.environment._app.config.get("FLASK_ASSETS_USE_CDN"):
             try:
-                from flask.ext.cdn import url_for
+                from flask_cdn import url_for
             except ImportError as e:
                 print("You must have Flask CDN to use FLASK_ASSETS_USE_CDN option")
                 raise e
@@ -352,7 +352,7 @@ class Environment(BaseEnvironment):
             self.register(name, bundles[name])
 
 try:
-    from flask.ext import script
+    import flask_script as script
 except ImportError:
     pass
 else:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,6 +1,6 @@
 from flask.app import Flask
 from webassets.test import TempEnvironmentHelper as BaseTempEnvironmentHelper
-from flask.ext.assets import Environment
+from flask_assets import Environment
 
 try:
     from flask import Blueprint

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ from tests.helpers import check_warnings
 
 from nose.tools import assert_raises
 from flask import Flask
-from flask.ext.assets import Environment
+from flask_assets import Environment
 from webassets.exceptions import ImminentDeprecationWarning
 
 try:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,7 +1,7 @@
 import os
 from nose.tools import assert_raises
 from flask import Flask
-from flask.ext.assets import Environment, Bundle
+from flask_assets import Environment, Bundle
 
 
 class TestEnv:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,15 +2,15 @@ from __future__ import absolute_import
 from nose.tools import assert_raises
 
 from flask import Flask
-from flask.ext.assets import Environment, Bundle
+from flask_assets import Environment, Bundle
 from webassets.bundle import get_all_bundle_files
 from tests.helpers import TempEnvironmentHelper, Module, Blueprint
 
 
 def test_import():
     # We want to expose these via the assets extension module.
-    from flask.ext.assets import Bundle
-    from flask.ext.assets import Environment
+    from flask_assets import Bundle
+    from flask_assets import Environment
 
 
 class TestUrlAndDirectory(TempEnvironmentHelper):

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -4,13 +4,13 @@ from nose import SkipTest
 
 # check for flask-script before importing things that fail if it's not present
 try:
-    from flask.ext.script import Manager
+    from flask_script import Manager
 except:
     raise SkipTest()
 
 import sys
 from flask import Flask
-from flask.ext.assets import Environment, ManageAssets
+from flask_assets import Environment, ManageAssets
 from webassets.script import GenericArgparseImplementation
 from tests.helpers import TempEnvironmentHelper
 


### PR DESCRIPTION
* Replace `import flask.ext.module` with `import flask_module` to avoid `ExtDeprecationWarning` in Flask 0.11

Fixes #102