### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,6 @@ Integrates the `webassets`_ library with Flask, adding support for
 merging, minifying and compiling CSS and Javascript files.
 
 Documentation:
-    http://flask-assets.readthedocs.org/
+    https://flask-assets.readthedocs.io/
 
 .. _webassets: http://github.com/miracle2k/webassets

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -178,7 +178,7 @@ you are using Flask-S3. Just set
 
     app.config['FLASK_ASSETS_USE_S3']=True
 
-.. _Flask-S3: https://flask-s3.readthedocs.org/en/v0.1.4/
+.. _Flask-S3: https://flask-s3.readthedocs.io/en/latest/
 
 Flask-CDN Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -194,7 +194,7 @@ you are using Flask-CDN. Just set
 
     app.config['FLASK_ASSETS_USE_CDN']=True
 
-.. _Flask-CDN: https://flask-cdn.readthedocs.org/en/v1.0.0/
+.. _Flask-CDN: https://flask-cdn.readthedocs.io/en/latest/
 .. _Amazon Cloudfront: https://aws.amazon.com/cloudfront/
 
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.