### PR TITLE
#coding: utf8 -> #coding: utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# coding: utf8
+# coding: utf-8
 """
 Flask-Assets
 -------------


### PR DESCRIPTION
When [putting together a build](https://github.com/conda-forge/staged-recipes/pull/1604) of `flask-assets` for [conda-forge](conda-forge.github.io), I was getting errors from our windows CI because of codec issues. It turns out that the `#coding: utf8` flag needs a hyphen in order for Windows to handle it correctly.