### PR TITLE
save app instance in Environment

### DIFF
--- a/src/flask_assets.py
+++ b/src/flask_assets.py
@@ -355,6 +355,7 @@ class Environment(BaseEnvironment):
     """The base url to which all static urls will be relative to.""")
 
     def init_app(self, app):
+        self.app = app
         app.jinja_env.add_extension('webassets.ext.jinja2.AssetsExtension')
         app.jinja_env.assets_environment = self
 


### PR DESCRIPTION
```Python
app = Flask(__name__)
assets = flask_assets.Environment()
assets.init_app(app)
```

seems not work with error

```
RuntimeError: assets instance not bound to an application, and no application in current context
```

It seems that the app not initialize in `init_app` and will always be `None`