### PR TITLE
Fix compatibility issue on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     name: tests
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]  # TODO: add windows-latest
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python: ['3.8', '3.9', '3.10', '3.11', '3.12']
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/src/flask_assets.py
+++ b/src/flask_assets.py
@@ -275,6 +275,9 @@ class FlaskResolver(Resolver):
         else:
             filename = rel_path
 
+        # Windows compatibility
+        filename = filename.replace("\\", "/")
+
         flask_ctx = None
         if not has_request_context():
             flask_ctx = ctx.environment._app.test_request_context()


### PR DESCRIPTION
Fix compatibility issue when converting a Windows path to a URL.

On Windows, the output of the following code is `['/static/foo%5Cbar']`, which works fine on Linux as `['/static/foo/bar']`. The issue arises from the difference between Windows' path separator (`\\`) and the URL separator (`/`), well on Linux, path separator is same as the URL separator.
```python
from flask import Flask
from flask_assets import Environment, Bundle

app = Flask(__name__)
env = Environment(app)
print(Bundle("foo/bar", env=env).urls())  
``` 
